### PR TITLE
feat: Add support for singularity

### DIFF
--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -50,7 +50,7 @@ class Container:
             raise ValueError("Must specify an image to run.")
 
         try:
-            subprocess.run(["hash", engine], check=True)
+            subprocess.run(["bash", "-c", f"'hash {engine}'"], check=True)
         except subprocess.CalledProcessError as err:
             raise OSError(f"{engine} does not exist on your system.") from err
 

--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -94,7 +94,7 @@ class Container:
                     *[f"--volume={local}:{host}" for local, host in self.mounts],
                     f"--workdir={self.cwd}",
                     *self.additional_options,
-                    self.image,
+                    f"docker://{self.image}",
                 ],
                 check=True,
             )
@@ -108,7 +108,7 @@ class Container:
                     f"--pwd={self.cwd}",
                     "--no-home",
                     *self.additional_options,
-                    self.name,
+                    f"{self.name}.sif",
                 ],
                 stdin=self.stdin_config,
                 stdout=self.stdout_config,

--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -89,7 +89,10 @@ class Container:
                 check=True,
             )
 
-            subprocess.run(["mkdir", *[host for _, host in self.mounts]], check=True)
+            subprocess.run(
+                ["mkdir", *[f"{self.name}.sif/{host}" for _, host in self.mounts]],
+                check=True,
+            )
         else:
             self.name = self.name or f"mario-mapyde-{uuid.uuid4()}"
 

--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -204,6 +204,8 @@ class Container:
 
         chdir = ""
         if cwd:
+            # singularity/apptainer mount host $TMPDIR into /tmp which might be
+            # unexpectedly full of files so make an empty temporary directory
             chdir = "cd $(mktemp -d)" if cwd == "/tmp" else f"cd {cwd}"
 
         env_assignments = (

--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -127,8 +127,6 @@ class Container:
                 stdin=self.stdin_config,
                 stdout=self.stdout_config,
             )
-            if self.cwd == "/tmp":
-                self.process.communicate(bytes("cd $(mktemp -d)", "utf-8"))
 
         else:
             self.process = subprocess.Popen(

--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -214,7 +214,7 @@ class Container:
 
         command = bytes(
             f"""{chdir}
-                env {env_assignments} {args!r}
+                env {env_assignments} {args.decode()}
                 """,
             "utf-8",
         )

--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -63,16 +63,6 @@ class Container:
         self.output = output
         self.additional_options = additional_options or []
 
-    @property
-    def entrypoint(self) -> list[str]:
-        """
-        The entrypoint for the given engine.
-        """
-        if self.engine in ["apptainer", "singularity"]:
-            return [self.engine, "oci"]
-
-        return [self.engine]
-
     def __enter__(self) -> Container:
 
         if self.engine in ["singularity", "apptainer"]:
@@ -185,11 +175,13 @@ class Container:
 
         assert isinstance(self.name, str)
 
-        subprocess.run(
-            [*self.entrypoint, "rm", "--force", "-v", self.name],
-            stdout=subprocess.DEVNULL,
-            check=False,
-        )
+        # singularity and apptainer do not have daemons
+        if self.engine not in ["singularity", "apptainer"]:
+            subprocess.run(
+                [self.engine, "rm", "--force", "-v", self.name],
+                stdout=subprocess.DEVNULL,
+                check=False,
+            )
 
         self.name = None
 

--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -50,7 +50,7 @@ class Container:
             raise ValueError("Must specify an image to run.")
 
         try:
-            subprocess.run(["command", "-v", engine], check=True)
+            subprocess.run(["hash", engine], check=True)
         except subprocess.CalledProcessError as err:
             raise OSError(f"{engine} does not exist on your system.") from err
 

--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -127,6 +127,9 @@ class Container:
                 stdin=self.stdin_config,
                 stdout=self.stdout_config,
             )
+            if self.cwd == "/tmp":
+                self.process.communicate(bytes("cd $(mktemp -d)", "utf-8"))
+
         else:
             self.process = subprocess.Popen(
                 [

--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -178,7 +178,7 @@ class Container:
             output = self.output_path.joinpath(self.logs_path).joinpath(
                 f"docker_{logfiletag}.log"
             )
-            output.mkdir(parents=True, exist_ok=True)
+            output.parent.mkdir(parents=True, exist_ok=True)
             with output.open("w", encoding="utf-8") as logfile:
                 subprocess.run(
                     [

--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -50,7 +50,7 @@ class Container:
             raise ValueError("Must specify an image to run.")
 
         try:
-            subprocess.run(["bash", "-c", f"'hash {engine}'"], check=True)
+            subprocess.run(["bash", "-c", f"hash {engine}"], check=True)
         except subprocess.CalledProcessError as err:
             raise OSError(f"{engine} does not exist on your system.") from err
 

--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -77,7 +77,7 @@ class Container:
                     self.engine,
                     "build",
                     f"{self.name}.sif",
-                    self.image,
+                    f"docker://{self.image}",
                 ],
                 check=True,
             )
@@ -94,7 +94,7 @@ class Container:
                     *[f"--volume={local}:{host}" for local, host in self.mounts],
                     f"--workdir={self.cwd}",
                     *self.additional_options,
-                    f"docker://{self.image}",
+                    self.image,
                 ],
                 check=True,
             )

--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -76,6 +76,7 @@ class Container:
                 [
                     self.engine,
                     "build",
+                    "--force",
                     f"{self.name}.sif",
                     f"docker://{self.image}",
                 ],
@@ -107,6 +108,7 @@ class Container:
                     *[f"--bind={local}:{host}" for local, host in self.mounts],
                     f"--pwd={self.cwd}",
                     "--no-home",
+                    "--writable-tmpfs",
                     *self.additional_options,
                     f"{self.name}.sif",
                 ],

--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -44,6 +44,11 @@ class Container:
         if not image:
             raise ValueError("Must specify an image to run.")
 
+        try:
+            subprocess.run(["command", "-v", engine], check=True)
+        except subprocess.CalledProcessError as err:
+            raise OSError(f"{engine} does not exist on your system.") from err
+
         self.image = image
         self.user = user or os.geteuid()
         self.group = group or os.getegid()

--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -174,9 +174,12 @@ class Container:
             # dump log files
             assert self.name
             logfiletag = self.name[self.name.rfind("__") + 2 :]
-            with self.output_path.joinpath(self.logs_path).joinpath(
+
+            output = self.output_path.joinpath(self.logs_path).joinpath(
                 f"docker_{logfiletag}.log"
-            ).open("w", encoding="utf-8") as logfile:
+            )
+            output.mkdir(parents=True, exist_ok=True)
+            with output.open("w", encoding="utf-8") as logfile:
                 subprocess.run(
                     [
                         self.engine,

--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -82,11 +82,14 @@ class Container:
                     self.engine,
                     "build",
                     "--force",
+                    "--sandbox",
                     f"{self.name}.sif",
                     f"docker://{self.image}",
                 ],
                 check=True,
             )
+
+            subprocess.run(["mkdir", *[host for _, host in self.mounts]], check=True)
         else:
             self.name = self.name or f"mario-mapyde-{uuid.uuid4()}"
 
@@ -113,7 +116,7 @@ class Container:
                     *[f"--bind={local}:{host}" for local, host in self.mounts],
                     f"--pwd={self.cwd}",
                     "--no-home",
-                    "--writable-tmpfs",
+                    "--writable",
                     *self.additional_options,
                     f"{self.name}.sif",
                 ],

--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -191,6 +191,11 @@ class Container:
         cwd: PathOrStr | None = None,
         env: dict[str, str] | None = None,
     ) -> tuple[bytes, bytes]:
+        """
+        Execute the provided command in the container. A smarter version of Container.process.communicate(args).
+
+        Optionally change the current working directory (cwd) and set some environment variables.
+        """
         if cwd is None:
             cwd = self.cwd
 

--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -119,6 +119,7 @@ class Container:
                     *[f"--bind={local}:{host}" for local, host in self.mounts],
                     f"--pwd={self.cwd}",
                     "--no-home",
+                    "--cleanenv",
                     "--writable",
                     *self.additional_options,
                     f"{self.name}.sif",

--- a/src/mapyde/container.py
+++ b/src/mapyde/container.py
@@ -93,19 +93,20 @@ class Container:
                     ],
                     check=True,
                 )
+
+                subprocess.run(
+                    [
+                        "mkdir",
+                        *[
+                            sif_path.joinpath(Path(container).relative_to("/"))
+                            for _, container in self.mounts
+                        ],
+                    ],
+                    check=True,
+                )
+
             else:
                 log.warning("%s already exists. Re-using it.", sif_path)
-
-            subprocess.run(
-                [
-                    "mkdir",
-                    *[
-                        sif_path.joinpath(Path(container).relative_to("/"))
-                        for _, container in self.mounts
-                    ],
-                ],
-                check=True,
-            )
 
             self.process = subprocess.Popen(
                 [

--- a/src/mapyde/runner.py
+++ b/src/mapyde/runner.py
@@ -87,7 +87,8 @@ def run_madgraph(config: ImmutableConfig) -> tuple[bytes, bytes]:
             engine=config["base"].get("engine", "docker"),
             mounts=mounts(config),
             stdout=sys.stdout,
-            output=(utils.output_path(config).joinpath(config["base"]["logs"])),
+            output_path=utils.output_path(config),
+            logs_path=config["base"]["logs"],
         ) as container:
             stdout, stderr = container.call(command)
 
@@ -110,7 +111,8 @@ def run_madgraph(config: ImmutableConfig) -> tuple[bytes, bytes]:
         engine=config["base"].get("engine", "docker"),
         mounts=mounts(config),
         stdout=sys.stdout,
-        output=(utils.output_path(config).joinpath(config["base"]["logs"])),
+        output_path=utils.output_path(config),
+        logs_path=config["base"]["logs"],
     ) as container:
         stdout, stderr = container.call(command)
 
@@ -144,7 +146,8 @@ rsync -rav --exclude hepmc . /data/""",
         engine=config["base"].get("engine", "docker"),
         mounts=mounts(config),
         stdout=sys.stdout,
-        output=(utils.output_path(config).joinpath(config["base"]["logs"])),
+        output_path=utils.output_path(config),
+        logs_path=config["base"]["logs"],
     ) as container:
         stdout, stderr = container.call(command)
 
@@ -262,7 +265,8 @@ rsync -rav . /data/""",
         engine=config["base"].get("engine", "docker"),
         mounts=mounts(config),
         stdout=sys.stdout,
-        output=(utils.output_path(config).joinpath(config["base"]["logs"])),
+        output_path=utils.output_path(config),
+        logs_path=config["base"]["logs"],
     ) as container:
         stdout, stderr = container.call(command)
 
@@ -287,7 +291,8 @@ def run_simpleanalysis(config: ImmutableConfig) -> tuple[bytes, bytes]:
         mounts=mounts(config),
         stdout=sys.stdout,
         cwd="/data",
-        output=(utils.output_path(config).joinpath(config["base"]["logs"])),
+        output_path=utils.output_path(config),
+        logs_path=config["base"]["logs"],
     ) as container:
         stdout, stderr = container.call(command)
 
@@ -316,7 +321,8 @@ def run_sa2json(config: ImmutableConfig) -> tuple[bytes, bytes]:
         engine=config["base"].get("engine", "docker"),
         mounts=mounts(config),
         stdout=sys.stdout,
-        output=(utils.output_path(config).joinpath(config["base"]["logs"])),
+        output_path=utils.output_path(config),
+        logs_path=config["base"]["logs"],
         cwd="/data",
     ) as container:
         stdout, stderr = container.call(command)
@@ -348,7 +354,8 @@ def run_pyhf(config: ImmutableConfig) -> tuple[bytes, bytes]:
         engine=config["base"].get("engine", "docker"),
         mounts=mounts(config),
         stdout=sys.stdout,
-        output=(utils.output_path(config).joinpath(config["base"]["logs"])),
+        output_path=utils.output_path(config),
+        logs_path=config["base"]["logs"],
         cwd="/data",
         additional_options=addl_opts,
     ) as container:
@@ -387,7 +394,8 @@ cp -a sherpa/ /data/" """,
         engine=config["base"].get("engine", "docker"),
         mounts=mounts(config),
         stdout=sys.stdout,
-        output=(utils.output_path(config).joinpath(config["base"]["logs"])),
+        output_path=utils.output_path(config),
+        logs_path=config["base"]["logs"],
     ) as container:
         stdout, stderr = container.call(command)
 
@@ -412,7 +420,8 @@ def run_root2hdf5(config: ImmutableConfig) -> tuple[bytes, bytes]:
         engine=config["base"].get("engine", "docker"),
         mounts=mounts(config),
         stdout=sys.stdout,
-        output=(utils.output_path(config).joinpath(config["base"]["logs"])),
+        output_path=utils.output_path(config),
+        logs_path=config["base"]["logs"],
         cwd="/data",
     ) as container:
         stdout, stderr = container.call(command)

--- a/src/mapyde/runner.py
+++ b/src/mapyde/runner.py
@@ -124,10 +124,10 @@ def run_delphes(config: ImmutableConfig) -> tuple[bytes, bytes]:
     # ./test/wrapper_delphes.py config_file
     image = f"ghcr.io/scipp-atlas/mario-mapyde/{config['delphes']['version']}"
     command = bytes(
-        f"""pwd && ls -lavh && ls -lavh /data && \
+        f"""cd $(mktemp -d) && pwd && ls -lavh && ls -lavh /data && \
 find /data/ -name "*hepmc.gz" && \
 cp $(find /data/ -name "*hepmc.gz") hepmc.gz && \
-gunzip hepmc.gz && \
+gunzip -f hepmc.gz && \
 cp /cards/delphes/{config['delphes']['card']} . && \
 /bin/ls -ltrh --color && \
 mkdir -p {Path(config['delphes']['output']).parent} && \

--- a/src/mapyde/runner.py
+++ b/src/mapyde/runner.py
@@ -128,7 +128,7 @@ def run_delphes(config: ImmutableConfig) -> tuple[bytes, bytes]:
     command = bytes(
         f"""pwd && ls -lavh && ls -lavh /data && \
 find /data/madgraph -name "*hepmc.gz" && \
-cp $(find /data/ -name "*hepmc.gz") hepmc.gz && \
+cp $(find /data/madgraph -name "*hepmc.gz") hepmc.gz && \
 gunzip -f hepmc.gz && \
 cp /cards/delphes/{config['delphes']['card']} . && \
 /bin/ls -ltrh --color && \

--- a/src/mapyde/runner.py
+++ b/src/mapyde/runner.py
@@ -276,7 +276,7 @@ def run_simpleanalysis(config: ImmutableConfig) -> tuple[bytes, bytes]:
 
     image = "gitlab-registry.cern.ch/atlas-sa/simple-analysis:master"
     command = bytes(
-        f"""simpleAnalysis -a {config['simpleanalysis']['name']} {config['analysis']['output']} -n""",
+        f"""/opt/SimpleAnalysis/ci/entrypoint.sh simpleAnalysis -a {config['simpleanalysis']['name']} {config['analysis']['output']} -n""",
         "utf-8",
     )
 

--- a/src/mapyde/runner.py
+++ b/src/mapyde/runner.py
@@ -124,7 +124,7 @@ def run_delphes(config: ImmutableConfig) -> tuple[bytes, bytes]:
     # ./test/wrapper_delphes.py config_file
     image = f"ghcr.io/scipp-atlas/mario-mapyde/{config['delphes']['version']}"
     command = bytes(
-        f"""cd $(mktemp -d) && pwd && ls -lavh && ls -lavh /data && \
+        f"""pwd && ls -lavh && ls -lavh /data && \
 find /data/ -name "*hepmc.gz" && \
 cp $(find /data/ -name "*hepmc.gz") hepmc.gz && \
 gunzip -f hepmc.gz && \

--- a/src/mapyde/runner.py
+++ b/src/mapyde/runner.py
@@ -332,7 +332,7 @@ def run_pyhf(config: ImmutableConfig) -> tuple[bytes, bytes]:
 
     image = f"ghcr.io/scipp-atlas/mario-mapyde/{config['pyhf']['image']}"
     command = bytes(
-        f"""time python3.8 /scripts/muscan.py -b /likelihoods/{config['pyhf']['likelihood']} -s {config['sa2json']['output']} -n {config['base']['output']} {config['pyhf']['gpu-options']}""",
+        f"""python3.8 /scripts/muscan.py -b /likelihoods/{config['pyhf']['likelihood']} -s {config['sa2json']['output']} -n {config['base']['output']} {config['pyhf']['gpu-options']}""",
         "utf-8",
     )
 

--- a/src/mapyde/runner.py
+++ b/src/mapyde/runner.py
@@ -89,7 +89,7 @@ def run_madgraph(config: ImmutableConfig) -> tuple[bytes, bytes]:
             stdout=sys.stdout,
             output=(utils.output_path(config).joinpath(config["base"]["logs"])),
         ) as container:
-            stdout, stderr = container.process.communicate(command)
+            stdout, stderr = container.call(command)
 
         # change config options back
         config["madgraph"]["proc"]["card"] = origcard
@@ -112,7 +112,7 @@ def run_madgraph(config: ImmutableConfig) -> tuple[bytes, bytes]:
         stdout=sys.stdout,
         output=(utils.output_path(config).joinpath(config["base"]["logs"])),
     ) as container:
-        stdout, stderr = container.process.communicate(command)
+        stdout, stderr = container.call(command)
 
     return stdout, stderr
 
@@ -146,7 +146,7 @@ rsync -rav --exclude hepmc . /data/""",
         stdout=sys.stdout,
         output=(utils.output_path(config).joinpath(config["base"]["logs"])),
     ) as container:
-        stdout, stderr = container.process.communicate(command)
+        stdout, stderr = container.call(command)
 
     return stdout, stderr
 
@@ -264,7 +264,7 @@ rsync -rav . /data/""",
         stdout=sys.stdout,
         output=(utils.output_path(config).joinpath(config["base"]["logs"])),
     ) as container:
-        stdout, stderr = container.process.communicate(command)
+        stdout, stderr = container.call(command)
 
     return stdout, stderr
 
@@ -289,7 +289,7 @@ def run_simpleanalysis(config: ImmutableConfig) -> tuple[bytes, bytes]:
         cwd="/data",
         output=(utils.output_path(config).joinpath(config["base"]["logs"])),
     ) as container:
-        stdout, stderr = container.process.communicate(command)
+        stdout, stderr = container.call(command)
 
     return stdout, stderr
 
@@ -319,7 +319,7 @@ def run_sa2json(config: ImmutableConfig) -> tuple[bytes, bytes]:
         output=(utils.output_path(config).joinpath(config["base"]["logs"])),
         cwd="/data",
     ) as container:
-        stdout, stderr = container.process.communicate(command)
+        stdout, stderr = container.call(command)
 
     return stdout, stderr
 
@@ -352,7 +352,7 @@ def run_pyhf(config: ImmutableConfig) -> tuple[bytes, bytes]:
         cwd="/data",
         additional_options=addl_opts,
     ) as container:
-        stdout, stderr = container.process.communicate(command)
+        stdout, stderr = container.call(command)
 
     return stdout, stderr
 
@@ -389,7 +389,7 @@ cp -a sherpa/ /data/" """,
         stdout=sys.stdout,
         output=(utils.output_path(config).joinpath(config["base"]["logs"])),
     ) as container:
-        stdout, stderr = container.process.communicate(command)
+        stdout, stderr = container.call(command)
 
     return stdout, stderr
 
@@ -415,6 +415,6 @@ def run_root2hdf5(config: ImmutableConfig) -> tuple[bytes, bytes]:
         output=(utils.output_path(config).joinpath(config["base"]["logs"])),
         cwd="/data",
     ) as container:
-        stdout, stderr = container.process.communicate(command)
+        stdout, stderr = container.call(command)
 
     return stdout, stderr

--- a/src/mapyde/runner.py
+++ b/src/mapyde/runner.py
@@ -127,7 +127,7 @@ def run_delphes(config: ImmutableConfig) -> tuple[bytes, bytes]:
     image = f"ghcr.io/scipp-atlas/mario-mapyde/{config['delphes']['version']}"
     command = bytes(
         f"""pwd && ls -lavh && ls -lavh /data && \
-find /data/ -name "*hepmc.gz" && \
+find /data/madgraph -name "*hepmc.gz" && \
 cp $(find /data/ -name "*hepmc.gz") hepmc.gz && \
 gunzip -f hepmc.gz && \
 cp /cards/delphes/{config['delphes']['card']} . && \

--- a/src/mapyde/runner.py
+++ b/src/mapyde/runner.py
@@ -84,6 +84,7 @@ def run_madgraph(config: ImmutableConfig) -> tuple[bytes, bytes]:
         with Container(
             image=image,
             name=f"{config['base']['output']}__mgpy",
+            engine=config["base"].get("engine", "docker"),
             mounts=mounts(config),
             stdout=sys.stdout,
             output=(utils.output_path(config).joinpath(config["base"]["logs"])),
@@ -106,6 +107,7 @@ def run_madgraph(config: ImmutableConfig) -> tuple[bytes, bytes]:
     with Container(
         image=image,
         name=f"{config['base']['output']}__mgpy",
+        engine=config["base"].get("engine", "docker"),
         mounts=mounts(config),
         stdout=sys.stdout,
         output=(utils.output_path(config).joinpath(config["base"]["logs"])),
@@ -139,6 +141,7 @@ rsync -rav --exclude hepmc . /data/""",
     with Container(
         image=image,
         name=f"{config['base']['output']}__delphes",
+        engine=config["base"].get("engine", "docker"),
         mounts=mounts(config),
         stdout=sys.stdout,
         output=(utils.output_path(config).joinpath(config["base"]["logs"])),
@@ -256,6 +259,7 @@ rsync -rav . /data/""",
     with Container(
         image=image,
         name=f"{config['base']['output']}__hists",
+        engine=config["base"].get("engine", "docker"),
         mounts=mounts(config),
         stdout=sys.stdout,
         output=(utils.output_path(config).joinpath(config["base"]["logs"])),
@@ -279,6 +283,7 @@ def run_simpleanalysis(config: ImmutableConfig) -> tuple[bytes, bytes]:
     with Container(
         image=image,
         name=f"{config['base']['output']}__simpleanalysis",
+        engine=config["base"].get("engine", "docker"),
         mounts=mounts(config),
         stdout=sys.stdout,
         cwd="/data",
@@ -308,6 +313,7 @@ def run_sa2json(config: ImmutableConfig) -> tuple[bytes, bytes]:
     with Container(
         image=image,
         name=f"{config['base']['output']}__SA2json",
+        engine=config["base"].get("engine", "docker"),
         mounts=mounts(config),
         stdout=sys.stdout,
         output=(utils.output_path(config).joinpath(config["base"]["logs"])),
@@ -339,6 +345,7 @@ def run_pyhf(config: ImmutableConfig) -> tuple[bytes, bytes]:
     with Container(
         image=image,
         name=f"{config['base']['output']}__muscan",
+        engine=config["base"].get("engine", "docker"),
         mounts=mounts(config),
         stdout=sys.stdout,
         output=(utils.output_path(config).joinpath(config["base"]["logs"])),
@@ -377,6 +384,7 @@ cp -a sherpa/ /data/" """,
     with Container(
         image=image,
         name=f"{config['base']['output']}__sherpa",
+        engine=config["base"].get("engine", "docker"),
         mounts=mounts(config),
         stdout=sys.stdout,
         output=(utils.output_path(config).joinpath(config["base"]["logs"])),
@@ -401,6 +409,7 @@ def run_root2hdf5(config: ImmutableConfig) -> tuple[bytes, bytes]:
     with Container(
         image=image,
         name=f"{config['base']['output']}__root2hdf5",
+        engine=config["base"].get("engine", "docker"),
         mounts=mounts(config),
         stdout=sys.stdout,
         output=(utils.output_path(config).joinpath(config["base"]["logs"])),

--- a/src/mapyde/utils.py
+++ b/src/mapyde/utils.py
@@ -5,8 +5,10 @@ Utilities for managing configuration.
 from __future__ import annotations
 
 import os
+import re
 import sys
 import typing as T
+import unicodedata
 from pathlib import Path
 
 import toml
@@ -106,3 +108,24 @@ def output_path(config: ImmutableConfig) -> Path:
     Return the output path from the config.
     """
     return Path(config["base"]["path"]).joinpath(config["base"]["output"]).resolve()
+
+
+def slugify(value: str, allow_unicode: bool = False) -> str:
+    """
+    Taken from https://github.com/django/django/blob/master/django/utils/text.py
+    Convert to ASCII if 'allow_unicode' is False. Convert spaces or repeated
+    dashes to single dashes. Remove characters that aren't alphanumerics,
+    underscores, or hyphens. Convert to lowercase. Also strip leading and
+    trailing whitespace, dashes, and underscores.
+    """
+    value = str(value)
+    if allow_unicode:
+        value = unicodedata.normalize("NFKC", value)
+    else:
+        value = (
+            unicodedata.normalize("NFKD", value)
+            .encode("ascii", "ignore")
+            .decode("ascii")
+        )
+    value = re.sub(r"[^\w\s-]", "", value.lower())
+    return re.sub(r"[-\s]+", "-", value).strip("-_")

--- a/templates/defaults.toml
+++ b/templates/defaults.toml
@@ -1,4 +1,5 @@
 [base]
+engine = "docker"
 path = "{{PWD}}"
 output = "output"
 logs = "logs"

--- a/templates/defaults.toml
+++ b/templates/defaults.toml
@@ -90,8 +90,8 @@ options = ""
 [pyhf]
 skip = true
 likelihood = "Higgsino_2L_bkgonly.json"
-image = "pyplotting-cuda:latest"
-gpu-options = ""
+image = "pyplotting:latest"
+gpu-options = "-c"
 
 [root2hdf5]
 input = "analysis/lowlevelAna.root"


### PR DESCRIPTION
Resolves #24.

This should support running singularity (and apptainer by extension) through mapyde.

```
python -m pip install 'mapyde @ git+https://github.com/scipp-atlas/mario-mapyde@feat/supportForSingularity'
```

and this config (note the `engine = "singularity"` portion)

```toml
[base]
engine = "singularity"
path = "{{PWD}}"
output = "mytag"

[madgraph.proc]
name = "charginos"
card = "{{madgraph['proc']['name']}}"

[madgraph.masses]
MN2 = 500
```

For UChicago's `af`, this recipe works

```
[22:30] login02.af.uchicago.edu:~ $ setupATLAS -q
[22:30] login02.af.uchicago.edu:~ $ lsetup "views dev4 latest/x86_64-centos7-gcc11-opt"
************************************************************************
Requested:  views ... 
 Setting up views dev4:latest/x86_64-centos7-gcc11-opt ... 
>>>>>>>>>>>>>>>>>>>>>>>>> Information for user <<<<<<<<<<<<<<<<<<<<<<<<<
************************************************************************
[22:30] login02.af.uchicago.edu:~ $ source mario-mapyde/venv/bin/activate
(venv) [22:30] login02.af.uchicago.edu:~ $ python -m pip install 'mapyde @ git+https://github.com/scipp-atlas/mario-mapyde@feat/supportForSingularity'
```