### PR TITLE
docs: Update nox command to run the mike deploy command

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -65,7 +65,7 @@ def mike(session: nox.Session) -> None:
     session.install(".[docs]")
 
     args = session.posargs or ["dev"]
-    print("mike", "deploy", "--branch", "gh-pages", *args)
+    session.run("mike", "deploy", "--branch", "gh-pages", *args)
 
 
 @nox.session


### PR DESCRIPTION
Now that we can confirm the environment works as expected, change `print` to `session.run` in `noxfile.py` to deploy.
